### PR TITLE
Ab#981 送信時にmp3ファイルに変換する

### DIFF
--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -95,8 +95,7 @@ async function getSecretManagerValue(secretId: string): Promise<string | null> {
 }
 
 async function speechToText(fileName: string): Promise<string | null> {
-    const client = new Speech.SpeechClient();
-
+    const client = new Speech.v1p1beta1.SpeechClient();
     const config = {
         languageCode: 'ja-JP',
         enableAutomaticPunctuation: true,

--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -31,11 +31,11 @@ getSecretManagerValue('send_email_address').then((result) => {
 
 
 function uploadFileToGCS(upFile: Buffer, onFinish: (fileName: string) => void, onError: (err: Error) => void) {
-    const fileName = uuidv4() + '.wav';
+    const fileName = uuidv4() + '.mp3';
     const storage = new Storage();
     const stream = storage.bucket(EnvironmentVariable.bucketName).file(fileName).createWriteStream({
         metadata: {
-            contentType: 'audio/wav',
+            contentType: 'audio/mp3',
         },
         resumable: false
     });

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -29,14 +29,16 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     const fetchedFile = await fetchFile(videoFile);
     ffmpeg.FS('writeFile', videoFile.name, fetchedFile);
     await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
-    return ffmpeg.FS('readFile', 'audio.wav');
+    return ffmpeg.FS('readFile', 'audio.mp3');
   }
 
   handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    assertIsSingle(event.target.files);
-    this.setState({
-      videoFile: event.target.files[0],
-    });
+    if (event.target.files != null) {
+      assertIsSingle(event.target.files);
+      this.setState({
+        videoFile: event.target.files[0],
+      });
+    }
 
 
     if (event.target.type === 'email') {

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -28,7 +28,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     await ffmpeg.load();
     const fetchedFile = await fetchFile(videoFile);
     ffmpeg.FS('writeFile', videoFile.name, fetchedFile);
-    await ffmpeg.run('-i', videoFile.name, '-ac', '1', 'audio.wav');
+    await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
     return ffmpeg.FS('readFile', 'audio.wav');
   }
 


### PR DESCRIPTION
## チケットへのリンク
- #35
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints16
## やったこと
- 動画をmp3ファイルに変換して送信する.
- ビットレートを54kbpsにする（Teamsの録画動画の音声に合わせて）
## やらないこと
- post送信時にbase64encodeせずに送信する(別プルリクエストで対応する)
## できるようになること(ユーザ目線）
- 圧縮することである程度の長さの動画を変換できるようになる(base64encodeをしないようにすれば1時間は遅れる計算)
## できなくなること(ユーザ目線)
- ２時間など長い動画は送れない
## 動作確認
1. 動画ファイルをメールアドレスと共にアップする
2. GCSにmp3ファイルが54kbpsでモノラル形式でアップロードされる
3. 文字起こし結果がメールに送信される
## その他
- 将来的にはGCSに直接ファイルを送ることで大容量ファイルにも対応したい