### PR TITLE
Ab#982 データ送信をjson形式からform形式に変更する #16

### DIFF
--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -95,8 +95,7 @@ async function getSecretManagerValue(secretId: string): Promise<string | null> {
 }
 
 async function speechToText(fileName: string): Promise<string | null> {
-    const client = new Speech.SpeechClient();
-
+    const client = new Speech.v1p1beta1.SpeechClient();
     const config = {
         languageCode: 'ja-JP',
         enableAutomaticPunctuation: true,

--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -127,8 +127,8 @@ async function speechToText(fileName: string): Promise<string | null> {
 
 const app: express.Express = express();
 
-//1時間あたり100mb程度なので2~3時間程度でbase64でファイルサイズが大きくなる(1.4倍)ことを予想する
-app.use(express.json({ limit: '420mb', type: 'application/*+json' }));
+//GAEの容量制限に合わせて
+app.use(express.json({ limit: '32mb', type: 'application/*+json' }));
 app.use(express.urlencoded({
     extended: false,
     type: 'application/x-www-form-urlencoded'

--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -30,12 +30,12 @@ getSecretManagerValue('send_email_address').then((result) => {
 });
 
 
-function uploadFileToGCS(upFile: Buffer, onFinish: (fileName: string) => void, onError: (err: Error) => void) {
-    const fileName = uuidv4() + '.wav';
+function uploadFileToGCS(upFile: File, onFinish: (fileName: string) => void, onError: (err: Error) => void) {
+    const fileName = uuidv4() + '.mp3';
     const storage = new Storage();
     const stream = storage.bucket(EnvironmentVariable.bucketName).file(fileName).createWriteStream({
         metadata: {
-            contentType: 'audio/wav',
+            contentType: 'audio/mp3',
         },
         resumable: false
     });
@@ -128,27 +128,30 @@ async function speechToText(fileName: string): Promise<string | null> {
 const app: express.Express = express();
 
 //1時間あたり100mb程度なので2~3時間程度でbase64でファイルサイズが大きくなる(1.4倍)ことを予想する
-app.use(express.json({ limit: '420mb' }));
+app.use(express.json({ limit: '420mb', type: 'application/*+json' }));
+app.use(express.urlencoded({
+    extended: false,
+    type: 'application/x-www-form-urlencoded'
+}))
 
 app.use(function (req, res, next) {
     res.header('Access-Control-Allow-Origin', '*');
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
     next();
 })
-
-app.post('/api/', multer().fields([]), (req: express.Request, res: express.Response) => {
-    const decodedFile = Buffer.from(req.body.file, "base64");
-    uploadFileToGCS(decodedFile, (fileName) => {
+const upload = multer({ dest: 'uploads/' });
+app.post('/api/', upload.single('file'), (req: express.Request, res: express.Response) => {
+    uploadFileToGCS(req.body.file, (fileName) => {
         speechToText(fileName).then((result) => {
             if (result === null) {
-                sendMail(null, req.body.mail, "文字を検出できませんでした");
+                sendMail(null, req.body.text, "文字を検出できませんでした");
             } else {
-                sendMail(result, req.body.mail, "文字起こしが完了しました。添付ファイルをご確認ください。");
+                sendMail(result, req.body.text, "文字起こしが完了しました。添付ファイルをご確認ください。");
             }
         })
     }, (err) => {
         console.error(err);
-        sendMail(null, req.body.mail, "文字起こしに失敗しました。");
+        sendMail(null, req.body.text, "文字起こしに失敗しました。");
     });
     res.send("success");
 });

--- a/express-nodejs/tsconfig.json
+++ b/express-nodejs/tsconfig.json
@@ -1,18 +1,17 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true, /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
@@ -23,9 +22,8 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -33,14 +31,12 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
-
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -49,22 +45,19 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true, /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -50,25 +50,32 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   }
 
   handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
-    try {
-      event.preventDefault();//ページ遷移を防ぐため
-      const address = this.state.emailAddress;
-      if (address == null || address === "") {
-        window.alert("メールアドレスを入力してください");
-        return;
-      }
-      const audioFile = await this.convertVideoToAudio(this.state.videoFile);
-      const encodedFile = Buffer.from(audioFile).toString('base64');
-      await axios.post("http://localhost:4000/api/", {
-        mail: address,
-        file: encodedFile
-      });
-      console.log("post request success");
-      window.alert("送信に成功しました");
-    } catch (error) {
-      console.log(console.error);
-      window.alert("送信に失敗しました");
+    event.preventDefault();//ページ遷移を防ぐため
+    const address = this.state.emailAddress;
+    if (address == null || address === "") {
+      window.alert("メールアドレスを入力してください");
+      return;
     }
+    const audioFile = await this.convertVideoToAudio(this.state.videoFile);
+    const params = new FormData();
+    params.append('text', address);
+    params.append('file', audioFile);
+    //const encodedFile = Buffer.from(audioFile).toString('base64');
+    await axios.post("http://localhost:4000/api/", params,
+      {
+        headers: {
+          'content-type': 'multipart/form-data',
+        },
+      })
+      .then(() => {
+        console.log("post request success");
+        window.alert("送信に成功しました");
+      })
+      .catch((error) => {
+        console.log(error);
+        window.alert("送信に失敗しました");
+      })
+
   }
 
   render() {

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -70,7 +70,14 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       return;
     }
 
-    axios.post("https://ojt-2020.uc.r.appspot.com/api/", formData, {
+    const postUrl = process.env.REACT_APP_POST_URL;
+    if (postUrl == null) {
+      console.error("POST先のURLが指定されていません");
+      window.alert("送信に失敗しました");
+      return;
+    }
+
+    axios.post(postUrl, formData, {
       headers: {
         'content-type': 'multipart/form-data'
       }

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -29,14 +29,16 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     const fetchedFile = await fetchFile(videoFile);
     ffmpeg.FS('writeFile', videoFile.name, fetchedFile);
     await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
-    return ffmpeg.FS('readFile', 'audio.wav');
+    return ffmpeg.FS('readFile', 'audio.mp3');
   }
 
   handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    assertIsSingle(event.target.files);
-    this.setState({
-      videoFile: event.target.files[0],
-    });
+    if (event.target.files != null) {
+      assertIsSingle(event.target.files);
+      this.setState({
+        videoFile: event.target.files[0],
+      });
+    }
 
 
     if (event.target.type === 'email') {

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -59,10 +59,17 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       window.alert("メールアドレスを入力してください");
       return;
     }
-    const audioFile = await this.convertVideoToAudio(this.state.videoFile);
     const formData = new FormData();
     formData.append('text', address);
-    formData.append('file', audioFile);
+    try {
+      const audioFile = await this.convertVideoToAudio(this.state.videoFile);
+      formData.append('file', audioFile);
+    } catch (error) {
+      window.alert('ファイルの変換に失敗しました');
+      console.error(error);
+      return;
+    }
+
 
     await axios.post("https://ojt-2020.uc.r.appspot.com/api/", formData, {
       headers: {
@@ -76,7 +83,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       .catch((error) => {
         console.log(error);
         window.alert("送信に失敗しました");
-      })
+      });
 
   }
 

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -70,8 +70,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       return;
     }
 
-
-    await axios.post("https://ojt-2020.uc.r.appspot.com/api/", formData, {
+    axios.post("https://ojt-2020.uc.r.appspot.com/api/", formData, {
       headers: {
         'content-type': 'multipart/form-data'
       }

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -28,7 +28,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     await ffmpeg.load();
     const fetchedFile = await fetchFile(videoFile);
     ffmpeg.FS('writeFile', videoFile.name, fetchedFile);
-    await ffmpeg.run('-i', videoFile.name, '-ac', '1', 'audio.wav');
+    await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
     return ffmpeg.FS('readFile', 'audio.wav');
   }
 


### PR DESCRIPTION
## チケットへのリンク
- #16
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints17
## やったこと
- post送信をmultipart/form-data形式で行う
- 自動スケーリングだと10分でタイムアウトしてしまうので基本スケーリングで20分に設定する(1時間の文字起こしにかかる時間が13~14分だったため)
 https://cloud.google.com/appengine/docs/standard/python/how-instances-are-managed?hl=ja#timeout
## やらないこと
- なし
## できるようになること(ユーザ目線）
- 1時間のファイルを変換することができるようになる。
## できなくなること(ユーザ目線)
- なし
## 動作確認
- 1時間のmp4動画をアップロードして文字起こし結果がメールに返ることを確認した。
- GCSに1時間のmp3ファイルが保存されていることを確認した
## その他
- 1時間のファイルになると文字起こし結果が返ってくるのに時間がかかる
- フロントエンドの変換にもそれなりに時間がかかるので進行度を表示したりする必要がありそう
    - issueに追加しておく #42 