### PR TITLE
Ab#1019 ファイル変換中に進行度を表示する

### DIFF
--- a/my-app-typescript/package-lock.json
+++ b/my-app-typescript/package-lock.json
@@ -1310,9 +1310,9 @@
       "integrity": "sha512-hemVFmhVLbD/VZaCG2BvCzFglKytMIMJ5aJfc12eXN4O4cG0wXnGTMVzlK1KKW/6viHhJMPkc9h4UDnJW8Uivg=="
     },
     "@ffmpeg/ffmpeg": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.9.5.tgz",
-      "integrity": "sha512-Vtxgi5C89n36pJ3I1/l6xd2qSwn+s1tAtLvFJ98N9P2ZorBvxXCEwTkt2yL7GuOUX9wpdG/vLFqp7iLso8LDwg==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.9.7.tgz",
+      "integrity": "sha512-WpZkNnqYGoaMcMd1EpaDi7nxRyEd05OjOTAfItH/ZwvAKJpr7ksvHKTC/NjP0li6mFrTFLGudP81J1tG0babdg==",
       "requires": {
         "is-url": "^1.2.4",
         "node-fetch": "^2.6.1",
@@ -6741,7 +6741,8 @@
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "optional": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -9547,6 +9548,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -9560,6 +9562,7 @@
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -9568,6 +9571,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -12747,7 +12751,8 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",
@@ -14337,7 +14342,8 @@
     "uuid": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/my-app-typescript/package-lock.json
+++ b/my-app-typescript/package-lock.json
@@ -1748,6 +1748,11 @@
         }
       }
     },
+    "@ramonak/react-progress-bar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ramonak/react-progress-bar/-/react-progress-bar-2.1.2.tgz",
+      "integrity": "sha512-G5VY8gYR1i9FfgxRL566Gyl8NCUL+UVf5+Dp7Zg6fHpBftV3BiMLHqX1VJYIs4N1TC8IwFKXkTFXLPJGEscMqA=="
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",

--- a/my-app-typescript/package.json
+++ b/my-app-typescript/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ffmpeg/core": "^0.8.5",
-    "@ffmpeg/ffmpeg": "^0.9.5",
+    "@ffmpeg/ffmpeg": "^0.9.7",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/my-app-typescript/package.json
+++ b/my-app-typescript/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@ffmpeg/core": "^0.8.5",
     "@ffmpeg/ffmpeg": "^0.9.7",
+    "@ramonak/react-progress-bar": "^2.1.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 interface convertVideoToAudioStateInterface {
   videoFile: File | undefined;
-  emailAddress: string;
+  emailAddress: string | undefined;
   buttonText: string;
   buttonDisabled: boolean;
 }
@@ -24,7 +24,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
 class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
-    this.state = { videoFile: undefined, emailAddress: '', buttonText: '送信', buttonDisabled: false };
+    this.state = { videoFile: undefined, emailAddress: undefined, buttonText: '送信', buttonDisabled: false };
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -6,6 +6,7 @@ interface convertVideoToAudioStateInterface {
   videoFile: File | null;
   emailAddress: string;
   buttonText: string;
+  buttonDisabled: boolean;
 }
 
 function assertIsSingle(files: FileList | null): asserts files is NonNullable<FileList> {
@@ -23,7 +24,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
 class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
-    this.state = { buttonText: '送信', videoFile: null, emailAddress: '' };
+    this.state = { videoFile: null, emailAddress: '', buttonText: '送信', buttonDisabled: false };
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({
@@ -32,11 +33,13 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     ffmpeg.setProgress(({ ratio }) => {
       if (ratio < 1) {
         this.setState({
-          buttonText: Math.round(100 * ratio) + '%'
+          buttonText: Math.round(100 * ratio) + '%',
+          buttonDisabled: true
         });
       } else {
         this.setState({
-          buttonText: '送信'
+          buttonText: '送信',
+          buttonDisabled: false
         })
       }
     })
@@ -110,7 +113,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
           <p>
             <label>ファイル:<input type="file" accept="video/mp4" onChange={this.handleChange} /></label>
           </p>
-          <input type="submit" value={this.state.buttonText} />
+          <input type="submit" value={this.state.buttonText} disabled={this.state.buttonDisabled} />
         </form>
       </div>
     );

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -44,9 +44,6 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       });
     });
     await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
-    this.setState({
-      isProcessing: false
-    });
     const resultFile = ffmpeg.FS('readFile', 'audio.mp3');
     const resultBlob = new Blob([resultFile.buffer], {
       type: 'audio/mp3'
@@ -88,11 +85,12 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       formData.append('file', audioFile);
     } catch (error) {
       window.alert('ファイルの変換に失敗しました');
+      console.error(error);
+      return;
+    } finally {
       this.setState({
         isProcessing: false
       });
-      console.error(error);
-      return;
     }
 
     const postUrl = process.env.REACT_APP_POST_URL;

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -32,23 +32,22 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     const ffmpeg = createFFmpeg({
       log: true
     });
-    ffmpeg.setProgress(({ ratio }) => {
-      if (ratio < 1) {
-        this.setState({
-          progress: Math.round(100 * ratio),
-          isProcessing: true
-        });
-      } else {
-        this.setState({
-          progress: 0,
-          isProcessing: false
-        });
-      }
+    this.setState({
+      progress: 0,
+      isProcessing: true
     });
     await ffmpeg.load();
     const fetchedFile = await fetchFile(videoFile);
     ffmpeg.FS('writeFile', videoFile.name, fetchedFile);
+    ffmpeg.setProgress(({ ratio }) => {
+      this.setState({
+        progress: Math.round(100 * ratio)
+      });
+    });
     await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
+    this.setState({
+      isProcessing: false
+    });
     const resultFile = ffmpeg.FS('readFile', 'audio.mp3');
     const resultBlob = new Blob([resultFile.buffer], {
       type: 'audio/mp3'
@@ -90,6 +89,9 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       formData.append('file', audioFile);
     } catch (error) {
       window.alert('ファイルの変換に失敗しました');
+      this.setState({
+        isProcessing: false
+      });
       console.error(error);
       return;
     }

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -10,7 +10,7 @@ interface convertVideoToAudioStateInterface {
 }
 
 function assertIsSingle(files: FileList | null): asserts files is NonNullable<FileList> {
-  if (files === undefined || files === null) {
+  if (files == null) {
     throw new Error(
       `filesが不正な値です,${files}でした`
     );
@@ -133,4 +133,3 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
 }
 
 export default MovieForm;
-

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -40,9 +40,9 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
         this.setState({
           buttonText: '送信',
           buttonDisabled: false
-        })
+        });
       }
-    })
+    });
     await ffmpeg.load();
     const fetchedFile = await fetchFile(videoFile);
     ffmpeg.FS('writeFile', videoFile.name, fetchedFile);

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -26,6 +26,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
     this.state = { videoFile: undefined, emailAddress: undefined, progress: 0, isProcessing: false };
+    //stateは省略せずにすべての要素を書く必要がある
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -4,10 +4,10 @@ import axios from 'axios';
 import ProgressBar from '@ramonak/react-progress-bar';
 
 interface convertVideoToAudioStateInterface {
-  videoFile: File | undefined;
-  emailAddress: string | undefined;
   progress: number;
   isProcessing: boolean;
+  videoFile?: File;
+  emailAddress?: string;
 }
 
 function assertIsSingle(files: FileList | null): asserts files is NonNullable<FileList> {
@@ -25,8 +25,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
 class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
-    this.state = { videoFile: undefined, emailAddress: undefined, progress: 0, isProcessing: false };
-    //stateは省略せずにすべての要素を書く必要がある
+    this.state = { progress: 0, isProcessing: false };
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -5,7 +5,7 @@ import axios from 'axios';
 interface convertVideoToAudioStateInterface {
   videoFile: File | undefined;
   emailAddress: string | undefined;
-  buttonText: string;
+  progress: number;
   isProcessing: boolean;
 }
 
@@ -24,7 +24,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
 class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
-    this.state = { videoFile: undefined, emailAddress: undefined, buttonText: '送信', isProcessing: false };
+    this.state = { videoFile: undefined, emailAddress: undefined, progress: 0, isProcessing: false };
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({
@@ -33,12 +33,12 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     ffmpeg.setProgress(({ ratio }) => {
       if (ratio < 1) {
         this.setState({
-          buttonText: Math.round(100 * ratio) + '%',
+          progress: Math.round(100 * ratio),
           isProcessing: true
         });
       } else {
         this.setState({
-          buttonText: '送信',
+          progress: 0,
           isProcessing: false
         });
       }
@@ -125,7 +125,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
           <p>
             <label>ファイル:<input type="file" accept="video/mp4" onChange={this.handleChange} /></label>
           </p>
-          <input type="submit" value={this.state.buttonText} disabled={this.state.isProcessing} />
+          <input type="submit" value={this.state.isProcessing ? this.state.progress + '%' : '送信'} disabled={this.state.isProcessing} />
         </form>
       </div>
     );

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -14,7 +14,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
     throw new Error(
       `filesが不正な値です,${files}でした`
     );
-  } else if (files.length !== 1) {
+  } else if (files.length > 1) {
     throw new Error(
       `files.lengthが不正な値です,${files.length}でした`
     );

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -3,7 +3,7 @@ import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
 import axios from 'axios';
 
 interface convertVideoToAudioStateInterface {
-  videoFile: File | null;
+  videoFile: File | undefined;
   emailAddress: string;
   buttonText: string;
   buttonDisabled: boolean;
@@ -24,7 +24,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
 class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
-    this.state = { videoFile: null, emailAddress: '', buttonText: '送信', buttonDisabled: false };
+    this.state = { videoFile: undefined, emailAddress: '', buttonText: '送信', buttonDisabled: false };
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -6,7 +6,7 @@ interface convertVideoToAudioStateInterface {
   videoFile: File | undefined;
   emailAddress: string | undefined;
   buttonText: string;
-  buttonDisabled: boolean;
+  isProcessing: boolean;
 }
 
 function assertIsSingle(files: FileList | null): asserts files is NonNullable<FileList> {
@@ -24,7 +24,7 @@ function assertIsSingle(files: FileList | null): asserts files is NonNullable<Fi
 class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   constructor() {
     super({});
-    this.state = { videoFile: undefined, emailAddress: undefined, buttonText: '送信', buttonDisabled: false };
+    this.state = { videoFile: undefined, emailAddress: undefined, buttonText: '送信', isProcessing: false };
   }
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({
@@ -34,12 +34,12 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
       if (ratio < 1) {
         this.setState({
           buttonText: Math.round(100 * ratio) + '%',
-          buttonDisabled: true
+          isProcessing: true
         });
       } else {
         this.setState({
           buttonText: '送信',
-          buttonDisabled: false
+          isProcessing: false
         });
       }
     });
@@ -125,7 +125,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
           <p>
             <label>ファイル:<input type="file" accept="video/mp4" onChange={this.handleChange} /></label>
           </p>
-          <input type="submit" value={this.state.buttonText} disabled={this.state.buttonDisabled} />
+          <input type="submit" value={this.state.buttonText} disabled={this.state.isProcessing} />
         </form>
       </div>
     );

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
 import axios from 'axios';
+import ProgressBar from '@ramonak/react-progress-bar';
 
 interface convertVideoToAudioStateInterface {
   videoFile: File | undefined;
@@ -125,7 +126,11 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
           <p>
             <label>ファイル:<input type="file" accept="video/mp4" onChange={this.handleChange} /></label>
           </p>
-          <input type="submit" value={this.state.isProcessing ? this.state.progress + '%' : '送信'} disabled={this.state.isProcessing} />
+          <input type="submit" value="送信" disabled={this.state.isProcessing} />
+          {this.state.isProcessing
+            ? <p><ProgressBar completed={this.state.progress} /></p>
+            : ''
+          }
         </form>
       </div>
     );


### PR DESCRIPTION
## チケットへのリンク
- #42 
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints17
## やったこと
- ffmpegで動画ファイルを変換している際に進行度をボタン上に表示する
- ffmpegで変換中はボタンを押せないようにする。
## やらないこと
- なし
## できるようになること(ユーザ目線）
- ファイルの変換状況を確認できるようになる
## できなくなること(ユーザ目線)
- なし
## 動作確認
1. 動画ファイルとメールアドレスをフォームに入力して送信ボタンを押す
2. ボタン上の文字が送信から変換状況を表す％表記に変わる、ボタンが押せなくなる。
3. 変換状況の進行に合わせてボタン上の％が進む。
4. 「送信が完了しました」とアラートが出た後にボタン上の文字が送信に戻りボタンが押せるようになる。
## その他
- この部分にバグがあったみたいで1/14に修正が入っている。よってffmpegのバージョンを新しくする必要あり
https://github.com/ffmpegwasm/ffmpeg.wasm/pull/139
