### PR TITLE
Ab#1021ファイル名に環境依存文字や記号が混じっていても変換できるようにする

### DIFF
--- a/express-nodejs/app.yaml
+++ b/express-nodejs/app.yaml
@@ -1,3 +1,7 @@
 runtime: nodejs12
 
-instance_class: F1
+instance_class: B1
+
+basic_scaling:
+  max_instances: 5
+  idle_timeout: 20m

--- a/express-nodejs/app.yaml
+++ b/express-nodejs/app.yaml
@@ -3,5 +3,5 @@ runtime: nodejs12
 instance_class: B1
 
 basic_scaling:
-  max_instances: 5
-  idle_timeout: 20m
+  max_instances: 10
+  idle_timeout: 30m

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -29,7 +29,7 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
   }
 
   componentDidMount() {
-    document.title = 'Teams会議の文字起こしツール'
+    document.title = 'Teams会議の文字起こしツール';
   }
 
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -45,8 +45,8 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     });
     await ffmpeg.load();
     const fetchedFile = await fetchFile(videoFile);
-    ffmpeg.FS('writeFile', 'video.mp4', fetchedFile);
-    await ffmpeg.run('-i', 'video.mp4', '-ac', '1', '-ab', '54k', 'audio.mp3');
+    ffmpeg.FS('writeFile', 'video', fetchedFile);
+    await ffmpeg.run('-i', 'video', '-ac', '1', '-ab', '54k', 'audio.mp3');
     const resultFile = ffmpeg.FS('readFile', 'audio.mp3');
     const resultBlob = new Blob([resultFile.buffer], {
       type: 'audio/mp3'

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -27,6 +27,11 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     super({});
     this.state = { progress: 0, isProcessing: false };
   }
+
+  componentDidMount() {
+    document.title = 'Teams会議の文字起こしツール'
+  }
+
   private async convertVideoToAudio(videoFile: File): Promise<Blob> {
     const ffmpeg = createFFmpeg({
       log: true

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -45,8 +45,8 @@ class MovieForm extends React.Component<{}, convertVideoToAudioStateInterface> {
     });
     await ffmpeg.load();
     const fetchedFile = await fetchFile(videoFile);
-    ffmpeg.FS('writeFile', videoFile.name, fetchedFile);
-    await ffmpeg.run('-i', videoFile.name, '-ac', '1', '-ab', '54k', 'audio.mp3');
+    ffmpeg.FS('writeFile', 'video.mp4', fetchedFile);
+    await ffmpeg.run('-i', 'video.mp4', '-ac', '1', '-ab', '54k', 'audio.mp3');
     const resultFile = ffmpeg.FS('readFile', 'audio.mp3');
     const resultBlob = new Blob([resultFile.buffer], {
       type: 'audio/mp3'


### PR DESCRIPTION
## チケットへのリンク
- #36 
- #37 
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints17
## やったこと
- ffmpegの変換時に元のファイル名を使用しないようにする
## やらないこと
- なし
## できるようになること(ユーザ目線）
- ファイル名に環境依存文字や記号が含まれていても送信できるようになる
## できなくなること(ユーザ目線)
- なし
## 動作確認
１．「testⅡ.mp4」というファイル名のファイルとメールアドレスをフォームから送信する
２．フォームに入力したメールアドレスに文字起こし結果が変える。

１．「【test】.mp4」というファイル名のファイルとメールアドレスをフォームから送信する
２．フォームに入力したメールアドレスに文字起こし結果が変える。

１．「test.wav」というファイル名のファイルとメールアドレスをフォームから送信する
２．フォームに入力したメールアドレスに文字起こし結果が変える。

１．「test.avi」というファイル名のファイルとメールアドレスをフォームから送信する
２．フォームに入力したメールアドレスに文字起こし結果が変える。
## その他
- 拡張子まで入っていなくてもffmpegが勝手に判断して変換してくれるらしい
- 複数のファイル形式を試したが問題なく動作した