### PR TITLE
Ab#1111 CORSの許可範囲を制限する

### DIFF
--- a/express-nodejs/.env
+++ b/express-nodejs/.env
@@ -1,0 +1,1 @@
+ALLOW_ORIGIN = "http://localhost:3000"

--- a/express-nodejs/app.yaml
+++ b/express-nodejs/app.yaml
@@ -5,3 +5,6 @@ instance_class: B1
 basic_scaling:
   max_instances: 10
   idle_timeout: 30m
+
+env_variables:
+  ALLOW_ORIGIN: "https://storage.googleapis.com/"

--- a/express-nodejs/app.yaml
+++ b/express-nodejs/app.yaml
@@ -7,4 +7,4 @@ basic_scaling:
   idle_timeout: 30m
 
 env_variables:
-  ALLOW_ORIGIN: "https://storage.googleapis.com/"
+  ALLOW_ORIGIN: "https://storage.googleapis.com"

--- a/express-nodejs/src/Express.ts
+++ b/express-nodejs/src/Express.ts
@@ -5,6 +5,9 @@ import { SendMail } from '#/sendMail'
 import { speechToText } from '#/speechToText'
 import Speech from '@google-cloud/speech'
 import { Storage } from '@google-cloud/storage'
+import dotenv from 'dotenv'
+
+dotenv.config();
 
 export class Express {
     /**
@@ -21,9 +24,9 @@ export class Express {
         private readonly sendMail: SendMail
     ) {
         this.app.use(function (req, res, next) {
-            //Expressではフォーム等の重要な情報を送っていないのでCORSを制限していない
+
             //バックエンドへのアクセス自体にはGAEでファイアウォールを設定している
-            res.header('Access-Control-Allow-Origin', '*');
+            res.header('Access-Control-Allow-Origin', process.env.ALLOW_ORIGIN);
             res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
             next();
         });

--- a/express-nodejs/src/Express.ts
+++ b/express-nodejs/src/Express.ts
@@ -21,6 +21,8 @@ export class Express {
         private readonly sendMail: SendMail
     ) {
         this.app.use(function (req, res, next) {
+            //Expressではフォーム等の重要な情報を送っていないのでCORSを制限していない
+            //バックエンドへのアクセス自体にはGAEでファイアウォールを設定している
             res.header('Access-Control-Allow-Origin', '*');
             res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
             next();

--- a/express-nodejs/src/Express.ts
+++ b/express-nodejs/src/Express.ts
@@ -10,20 +10,18 @@ export class Express {
     /**
      * Expressでリクエストを受け取る
      * @param app Expressモジュール
-     * @param allowOrigin リソースへのアクセスを許可するオリジン
      * @param storage GoogleCloudStorageのモジュール
      * @param bucketName 保存先のバケット名
      * @param sendMail SendMailクラス
      */
     constructor(
         private readonly app: express.Express,
-        private readonly allowOrigin: string,
         private readonly storage: Storage,
         private readonly bucketName: string,
         private readonly sendMail: SendMail
     ) {
         this.app.use(function (req, res, next) {
-            res.header('Access-Control-Allow-Origin', allowOrigin);
+            res.header('Access-Control-Allow-Origin', '*');
             res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
             next();
         });

--- a/express-nodejs/src/Express.ts
+++ b/express-nodejs/src/Express.ts
@@ -10,18 +10,20 @@ export class Express {
     /**
      * Expressでリクエストを受け取る
      * @param app Expressモジュール
+     * @param allowOrigin リソースへのアクセスを許可するオリジン
      * @param storage GoogleCloudStorageのモジュール
      * @param bucketName 保存先のバケット名
      * @param sendMail SendMailクラス
      */
     constructor(
         private readonly app: express.Express,
+        private readonly allowOrigin: string,
         private readonly storage: Storage,
         private readonly bucketName: string,
         private readonly sendMail: SendMail
     ) {
         this.app.use(function (req, res, next) {
-            res.header('Access-Control-Allow-Origin', '*');
+            res.header('Access-Control-Allow-Origin', allowOrigin);
             res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
             next();
         });

--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -8,7 +8,6 @@ import express from 'express'
     const fromAddress = await getSecretValue('send_email_address');
     const bucketName = await getSecretValue('meeting_voice_file_dir');
     const sendGridApiKey = await getSecretValue('sendgrid_api_key')
-    const allowOrigin = await getSecretValue('allow_origin');
     if (fromAddress == null) {
         throw new Error("送信元アドレスの取得に失敗しました");
     }
@@ -18,12 +17,8 @@ import express from 'express'
     if (sendGridApiKey == null) {
         throw new Error('sendGridのAPIキーの取得に失敗しました');
     }
-    if (allowOrigin == null) {
-        throw new Error('allowOriginの取得に失敗しました');
-    }
     const expressClass = new Express(
         express(),
-        allowOrigin,
         new Storage(),
         bucketName,
         new SendMail(sendGridApiKey, fromAddress),

--- a/express-nodejs/src/index.ts
+++ b/express-nodejs/src/index.ts
@@ -8,6 +8,7 @@ import express from 'express'
     const fromAddress = await getSecretValue('send_email_address');
     const bucketName = await getSecretValue('meeting_voice_file_dir');
     const sendGridApiKey = await getSecretValue('sendgrid_api_key')
+    const allowOrigin = await getSecretValue('allow_origin');
     if (fromAddress == null) {
         throw new Error("送信元アドレスの取得に失敗しました");
     }
@@ -17,8 +18,12 @@ import express from 'express'
     if (sendGridApiKey == null) {
         throw new Error('sendGridのAPIキーの取得に失敗しました');
     }
+    if (allowOrigin == null) {
+        throw new Error('allowOriginの取得に失敗しました');
+    }
     const expressClass = new Express(
         express(),
+        allowOrigin,
         new Storage(),
         bucketName,
         new SendMail(sendGridApiKey, fromAddress),


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints19?workitem=1111
## やったこと
- CORSの許可を環境変数から設定した。
- デバック時は.envから環境変数を供給し、GAEで実行時はapp.yamlから環境変数を供給する
## やらないこと
- webpackなどで環境変数を設定すること
## できるようになること(ユーザ目線）
- なし
## できなくなること(ユーザ目線)
- なし
## 動作確認
### デバック時
１．http://localhost:3000 からフォームを送信する
２．送信に成功しましたとアラートが表示される

１．https://storage.googleapis.com/ からフォームを送信する
２．CORS policyでブロックしたとコンソールログに表示される

### GAE実行時
1.　https://storage.googleapis.com/ からフォームを送信する
2.　送信に成功しましたとアラートが表示される

１．http://localhost:3000 からフォームを送信する
２．CORS policyでブロックしたとコンソールログに表示される

## その他
- GAE側でファイアウォールを設定してR-WAN以外からのアクセスを受けつけないようにしている。