### PR TITLE
AB#1158 GAEのdeploy時に実行するnpm scriptsであるstartを変更する

### DIFF
--- a/express-nodejs/package-lock.json
+++ b/express-nodejs/package-lock.json
@@ -581,9 +581,9 @@
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "body-parser": {
@@ -712,14 +712,14 @@
       }
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1397,9 +1397,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -2204,6 +2204,17 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -2349,19 +2360,6 @@
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
         "path-type": "^1.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        }
       }
     },
     "read-pkg-up": {
@@ -2789,9 +2787,9 @@
       }
     },
     "ts-node-dev": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.0.0.tgz",
-      "integrity": "sha512-leA/3TgGtnVU77fGngBwVZztqyDRXirytR7dMtMWZS5b2hGpLl+VDnB0F/gf3A+HEPSzS/KwxgXFP7/LtgX4MQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.1.tgz",
+      "integrity": "sha512-kAO8LUZgXZSY0+PucMPsQ0Bbdv0x+lgbN7j8gcD4PuTI4uKC6YchekaspmYTBNilkiu+rQYkWJA7cK+Q8/B0tQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.4.0",

--- a/express-nodejs/package.json
+++ b/express-nodejs/package.json
@@ -27,10 +27,9 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "ts-node --files -r tsconfig-paths/register src/index.ts",
+    "start": "ts-node --files -r tsconfig-paths/register src/index.ts",
     "dev:watch": "ts-node-dev  src/index.ts",
-    "gcp-build": "tsc",
-    "start": "node src/index.js"
+    "gcp-build": "tsc"
   },
   "author": "",
   "license": "ISC"

--- a/express-nodejs/package.json
+++ b/express-nodejs/package.json
@@ -23,10 +23,11 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "ts-node-dev": "^1.0.0"
+    "ts-node-dev": "^1.1.1"
   },
   "scripts": {
-    "start": "ts-node --files -r tsconfig-paths/register src/index.ts"
+    "start": "ts-node --files -r tsconfig-paths/register src/index.ts",
+    "dev": "ts-node-dev --files -r tsconfig-paths/register src/index.ts"
   },
   "author": "",
   "license": "ISC"

--- a/express-nodejs/package.json
+++ b/express-nodejs/package.json
@@ -26,10 +26,7 @@
     "ts-node-dev": "^1.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "ts-node --files -r tsconfig-paths/register src/index.ts",
-    "dev:watch": "ts-node-dev  src/index.ts",
-    "gcp-build": "tsc"
+    "start": "ts-node --files -r tsconfig-paths/register src/index.ts"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints19?workitem=1158
## やったこと
- packege.jsonのscripts startをts-nodeを使って実行する方法に変えた
- GAEにdeployをするときはpackage.jsonのscripts startが実行される。ts-nodeを使った場合も問題なくdeployできたのでtsファイルから直接実行できるこの方法に変更する
## やらないこと
- なし
## できるようになること(ユーザ目線）
- なし
## できなくなること(ユーザ目線)
- なし
## 動作確認
１．GAE上でgcloud app deployを実行する
２．フォームからGAE上のexpressサーバにメールアドレスと、動画ファイルを送信する
３．実行結果がメールアドレスに返る
## その他
