### PR TITLE
Ab#1211 変換のプログレスが100％になった後に送信中のメッセージを追加する

### DIFF
--- a/my-app-typescript/src/App.css
+++ b/my-app-typescript/src/App.css
@@ -5,3 +5,7 @@
     color: red;
     font-size: 14;
 }
+.message{
+    text-align: center;
+    font-size: 120%;
+}

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -96,7 +96,7 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
     }
     catch (error) {
       console.error(error);
-      window.alert("メールの送信に失敗しました");
+      window.alert("送信に失敗しました");
     } finally {
       this.setState({
         isProcessing: false

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -7,8 +7,9 @@ import { assertIsSingle } from './assertIsSingle'
 import './App.css'
 
 interface convertVideoToAudioStateInterface {
-  progress: number | string;
+  progress: number;
   isProcessing: boolean;
+  message?: string
   videoFile?: File;
   emailAddress?: string;
 }
@@ -70,15 +71,9 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       isProcessing: true
     });
     ffmpeg.setProgress(({ ratio }) => {
-      if (ratio == 1) {
-        this.setState({
-          progress: "送信中"
-        })
-      } else {
-        this.setState({
-          progress: Math.round(100 * ratio)
-        });
-      }
+      this.setState({
+        progress: Math.round(100 * ratio)
+      });
     });
     let audioBlob: Blob;
     try {
@@ -92,6 +87,9 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       return;
     }
     try {
+      this.setState({
+        message: "~送信中~"
+      })
       await requestTranscription(this.state.emailAddress, audioBlob, this.requestUrl);
       console.log("送信に成功しました");
       window.alert("送信に成功しました");
@@ -101,7 +99,8 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       window.alert("送信に失敗しました");
     } finally {
       this.setState({
-        isProcessing: false
+        isProcessing: false,
+        message: ""
       });
     }
   }
@@ -127,6 +126,7 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
             ? <p><ProgressBar completed={this.state.progress} /></p>
             : ''
           }
+          <p className="message">{this.state.message}</p>
         </form>
       </div>
     );

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -95,6 +95,7 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       await requestTranscription(this.state.emailAddress, audioBlob, this.requestUrl);
     }
     catch (error) {
+      console.error(error);
       window.alert("メールの送信に失敗しました");
     } finally {
       this.setState({

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -93,6 +93,8 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
     }
     try {
       await requestTranscription(this.state.emailAddress, audioBlob, this.requestUrl);
+      console.log("送信に成功しました");
+      window.alert("送信に成功しました");
     }
     catch (error) {
       console.error(error);

--- a/my-app-typescript/src/requestTranscription.ts
+++ b/my-app-typescript/src/requestTranscription.ts
@@ -6,23 +6,17 @@ import axios from 'axios';
  * @param audioFile 文字起こしするオーディオファイル
  * @param requestUrl 送信先のURL
  */
-export function requestTranscription(emailAddress: string, audioFile: Blob, requestUrl: string) {
+export async function requestTranscription(emailAddress: string, audioFile: Blob, requestUrl: string) {
     const formData = new FormData;
     formData.append("text", emailAddress);
     formData.append("file", audioFile);
 
-    axios.post(requestUrl, formData, {
+    await axios.post(requestUrl, formData, {
         headers: {
             'content-type': 'multipart/form-data'
         }
-    })
-        .then(() => {
-            console.log("post request success");
-            window.alert("送信に成功しました");
-        })
-        .catch((error) => {
-            console.log(error);
-            window.alert("送信に失敗しました");
-        });
+    });
+    console.log("送信に成功しました");
+    window.alert("送信に成功しました");
 
 }

--- a/my-app-typescript/src/requestTranscription.ts
+++ b/my-app-typescript/src/requestTranscription.ts
@@ -16,7 +16,4 @@ export async function requestTranscription(emailAddress: string, audioFile: Blob
             'content-type': 'multipart/form-data'
         }
     });
-    console.log("送信に成功しました");
-    window.alert("送信に成功しました");
-
 }


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints20?workitem=1211
## やったこと
- 変換が100％になった後に送信中とProgressBarに表示する。
## やらないこと
- 送信中のラベルが出るタイミングとバーが右端に行くタイミングがあっていないがそのままにする。
## できるようになること(ユーザ目線）
- 変換が終わった後に送信中であることがわかる。
## できなくなること(ユーザ目線)
- なし。
## 動作確認
### ファイル送信に成功する場合
１．フォームにメールアドレスと動画ファイルを入力して送信ボタンを押す。
２．変換が始まってProgressBarが動く。
３．変換が終わるとProgressBarの表示が送信中に変わる。
４．送信に成功しましたとアラートがでる。
５．OKを押すとProgressBarが消える。
### ファイル送信に失敗する場合
１．フォームにメールアドレスと動画ファイルを入力して送信ボタンを押す。
２．変換が始まってProgressBarが動く。
３．変換が終わるとProgressBarの表示が送信中に変わる。
４．送信に失敗しましたとアラートがでる。
５．OKを押すとProgressBarが消える。
### ファイルの変換に失敗する場合
１．フォームにメールアドレスと画像ファイルを入力して送信ボタンを押す。
２．変換に失敗しましたとアラートが表示される。
３．OKを押すとProgressBarが消える。
## その他