### PR TITLE
AB#1223 フロントエンドのnpm管理にdevDependenciesを用いる

### DIFF
--- a/my-app-typescript/package.json
+++ b/my-app-typescript/package.json
@@ -3,24 +3,6 @@
   "version": "0.1.0",
   "homepage": "./",
   "private": true,
-  "dependencies": {
-    "@ffmpeg/core": "^0.8.5",
-    "@ffmpeg/ffmpeg": "^0.9.7",
-    "@ramonak/react-progress-bar": "^2.1.2",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
-    "@types/jest": "^26.0.15",
-    "@types/node": "^12.19.6",
-    "@types/react-dom": "^16.9.8",
-    "axios": "^0.21.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "react-scripts": "4.0.0",
-    "typescript": "^4.0.5",
-    "use-file-upload": "^1.0.9",
-    "web-vitals": "^0.2.4"
-  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
@@ -46,6 +28,22 @@
     ]
   },
   "devDependencies": {
-    "@types/react": "^16.9.56"
+    "@types/react": "^16.9.56",
+    "@ffmpeg/core": "^0.8.5",
+    "@ffmpeg/ffmpeg": "^0.9.7",
+    "@ramonak/react-progress-bar": "^2.1.2",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^12.19.6",
+    "@types/react-dom": "^16.9.8",
+    "axios": "^0.21.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-scripts": "4.0.0",
+    "typescript": "^4.0.5",
+    "use-file-upload": "^1.0.9",
+    "web-vitals": "^0.2.4"
   }
 }


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints20?workitem=1223
## やったこと
- package.jsonのdepndenciesの部分をdevDependenciesに変更する。
## やらないこと
- なし
## できるようになること(ユーザ目線）
- なし
## できなくなること(ユーザ目線)
- なし
## 動作確認
1. 「npm run build」でビルドを行う。
2. ビルドしたファイルをGoogleCloudStorageにおいて公開する。
3. GCSの公開URLにアクセスしてWebページを表示する。
4. 文字起こしを実行できる。
## その他
