### PR TITLE
[update] AB#1267 インスタンスクラスを大きいものに変更する

### DIFF
--- a/express-nodejs/app.yaml
+++ b/express-nodejs/app.yaml
@@ -1,6 +1,6 @@
 runtime: nodejs12
 
-instance_class: B1
+instance_class: B2
 
 basic_scaling:
   max_instances: 10


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints21?workitem=1267
## やったこと
- GAEのメモリが不足していると表示される
- そのためGAEのインスタンスをB1からB2に変更した
## やらないこと
- なし
## できるようになること(ユーザ目線）
- １時間までの容量のファイルを変換することができる
## できなくなること(ユーザ目線)
- なし
## 動作確認
1. １時間の動画ファイルをメールアドレスと共に送信する
2. 実行結果がメールアドレスに送信される
## その他
- なし