### PR TITLE
Ab#1265 自動でリリースノートを作れるようにする

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,16 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: 'Breaking change'
+    labels:
+      - 'Breaking Change'
+  - title: 'Fixes'
+    labels:
+      - 'bug'
+  - title: 'Refactor'
+    labels:
+      - 'refactor'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints21?workitem=1265
## やったこと
- Release Drafterを使ってリリースノートを自動で作成できるようにする
## やらないこと
- なし
## できるようになること(ユーザ目線）
- なし
## できなくなること(ユーザ目線)
- なし
## 動作確認
- GitHubのリポジトリにマージしないと動作しないので確認できない
## その他
- Release Drafter導入後のPRにしか適用されない
- PRのラベルに応じてリリースノートの表示を分けることができる
- 現在ラベルを使っていないのでPRにラベルを必要に応じてつける（Breaking Change,bug,refactor)