### PR TITLE
[add] AB#1270 react-scripts-start時はipアドレスを確認しない

### DIFF
--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -10,7 +10,7 @@ import { isRWAN } from './isRWAN'
 interface convertVideoToAudioStateInterface {
   progress: number;
   isProcessing: boolean;
-  isRWAN?: boolean;
+  drawForm?: boolean;
   message?: string
   videoFile?: File;
   emailAddress?: string;
@@ -30,8 +30,11 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
 
   async componentDidMount() {
     document.title = 'Teams会議の文字起こしツール';
+
     this.setState({
-      isRWAN: await isRWAN()
+      drawForm: process.env.NODE_ENV === "development"
+        ? true
+        : await isRWAN()
     });
   }
 
@@ -134,11 +137,11 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
   }
 
   render() {
-    if (this.state.isRWAN == null) return <p>Loading page...</p>;
+    if (this.state.drawForm == null) return <p>Loading page...</p>;
     return (
       <div>
         <h1>OJTテーマ：Teams会議の文字起こしツール</h1>
-        {this.state.isRWAN
+        {this.state.drawForm
           ? <this.uploadForm />
           : <h3 className="R-WAN">※R-WANで接続してください</h3>
         }


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints21?workitem=1270
## やったこと
- localhost上でipinfo.ioからIPアドレスを取得しようとすると429 エラーになってしまう
- そこでreact-scripts start実行時はIPアドレスを確認せずフォームを表示するようにする
## やらないこと
- なし
## できるようになること(ユーザ目線）
- なし
## できなくなること(ユーザ目線)
- なし
## 動作確認
### react-scripts start実行時
１．npm run startで実行する。
２．localhostに接続する。
２．R-WANに接続しているかに関わらずフォームが表示される。
### react-scripts build実行時
１．ビルドしたファイルをGCSに保存して公開する。
２．公開したURLにアクセスする。
３．R-WANに接続しているとフォームが、そうでない場合はメッセージが表示される。
## その他
- react-scriptsは自動で環境変数をセットしてくれる

script | process.env.NODE_ENV
-- | --
build | production
test | test
start | development

