### PR TITLE
Ab#1212 送信後にユーザがする作業をメッセージに追加する

### DIFF
--- a/my-app-typescript/src/App.css
+++ b/my-app-typescript/src/App.css
@@ -5,6 +5,5 @@
     font-size: 80%;
 }
 .message{
-    text-align: center;
     font-size: 120%;
 }

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -101,7 +101,8 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       })
       await requestTranscription(this.state.emailAddress, audioBlob, this.requestUrl);
       console.log("送信に成功しました");
-      window.alert("送信に成功しました");
+      window.alert("送信に成功しました。\n文字起こし結果が " + this.state.emailAddress
+        + " に送られますのでご確認ください。\n" + "送信には動画時間の半分程度かかります。");
     }
     catch (error) {
       console.error(error);

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -65,11 +65,15 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
   handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();//ページ遷移を防ぐため
     if (this.state.emailAddress == null || this.state.emailAddress === "") {
-      window.alert("メールアドレスを入力してください");
+      this.setState({
+        message: "メールアドレスを入力してください"
+      });
       return;
     }
     if (this.state.videoFile == null) {
-      window.alert("ファイルを選択してください");
+      this.setState({
+        message: "ファイルを選択してください"
+      });
       return;
     }
     const ffmpeg = createFFmpeg({
@@ -77,7 +81,8 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
     });
     this.setState({
       progress: 0,
-      isProcessing: true
+      isProcessing: true,
+      message: ""
     });
     ffmpeg.setProgress(({ ratio }) => {
       this.setState({
@@ -88,9 +93,9 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
     try {
       audioBlob = await convertVideoToAudio(this.state.videoFile, ffmpeg);
     } catch (error) {
-      window.alert('ファイルの変換に失敗しました');
       this.setState({
-        isProcessing: false
+        isProcessing: false,
+        message: "ファイルの変換に失敗しました"
       });
       console.error(error);
       return;
@@ -101,16 +106,19 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       })
       await requestTranscription(this.state.emailAddress, audioBlob, this.requestUrl);
       console.log("送信に成功しました");
-      window.alert("送信に成功しました。\n文字起こし結果は " + this.state.emailAddress
-        + " に送られます。\n" + "送信には動画時間の半分程度かかります。");
+      this.setState({
+        message: "送信に成功しました。文字起こし結果は " + this.state.emailAddress
+          + " に送られます。" + "送信には動画時間の半分程度かかります。"
+      });
     }
     catch (error) {
       console.error(error);
-      window.alert("送信に失敗しました");
+      this.setState({
+        message: "送信に失敗しました。"
+      });
     } finally {
       this.setState({
         isProcessing: false,
-        message: ""
       });
     }
   }

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -101,8 +101,8 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       })
       await requestTranscription(this.state.emailAddress, audioBlob, this.requestUrl);
       console.log("送信に成功しました");
-      window.alert("送信に成功しました。\n文字起こし結果が " + this.state.emailAddress
-        + " に送られますのでご確認ください。\n" + "送信には動画時間の半分程度かかります。");
+      window.alert("送信に成功しました。\n文字起こし結果は " + this.state.emailAddress
+        + " に送られます。\n" + "送信には動画時間の半分程度かかります。");
     }
     catch (error) {
       console.error(error);

--- a/my-app-typescript/src/App.tsx
+++ b/my-app-typescript/src/App.tsx
@@ -108,7 +108,7 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
       console.log("送信に成功しました");
       this.setState({
         message: "送信に成功しました。文字起こし結果は " + this.state.emailAddress
-          + " に送られます。" + "送信には動画時間の半分程度かかります。"
+          + " に送られます。\n" + "結果の返信には動画時間の半分程度かかりますが、ブラウザは閉じて構いません。"
       });
     }
     catch (error) {
@@ -140,7 +140,11 @@ class App extends React.Component<{}, convertVideoToAudioStateInterface> {
           ? <p><ProgressBar completed={this.state.progress} /></p>
           : ''
         }
-        <p className="message">{this.state.message}</p>
+        <div className="message">{
+          this.state.message?.split('\n').map((str, index) => (
+            <React.Fragment key={index}>{str}<br /></React.Fragment>
+          ))
+        }</div>
       </form>
     )
   }


### PR DESCRIPTION
## チケットへのリンク
- https://dev.azure.com/ShinyaTanaka1/OJT/_sprints/taskboard/OJT%20Team/OJT/Sprints21?workitem=1212
## やったこと
- フォームの送信に成功したらメッセージを表示する。
- メッセージにはユーザがこの後どうするかを書く。
- アラートでメッセージを出していたものをメッセージエリアに変更する
## やらないこと
- なし。
## できるようになること(ユーザ目線）
- 送信後にユーザがする動作がわかる。
## できなくなること(ユーザ目線)
- なし。
## 動作確認
１．フォームから動画とメールアドレスを入力して送信ボタンを押す。
２．メッセージが表示される。
![image](https://user-images.githubusercontent.com/74222581/109094112-d0e07680-775c-11eb-86fc-5818242bd2ad.png)

１．フォームにメールアドレスを入力せずに送信ボタンを押す。
２．メッセージが表示される。
![image](https://user-images.githubusercontent.com/74222581/109094319-19982f80-775d-11eb-81d1-66ebfef750f3.png)

１．ファイルを選択肢ないでフォームを送信する。
２．メッセージが表示される。
![image](https://user-images.githubusercontent.com/74222581/109094386-346aa400-775d-11eb-9b82-ca6274d4ccf0.png)

１．フォームにメールアドレスとtxtファイルを入力して送信する。
２．メッセージが表示される。
![image](https://user-images.githubusercontent.com/74222581/109094483-624fe880-775d-11eb-85fa-3a57878316ba.png)

### バックエンドサーバが落ちている場合
１．フォームにファイルとメールアドレスを入力して送信する。
２．メッセージが表示される
![image](https://user-images.githubusercontent.com/74222581/109094607-a04d0c80-775d-11eb-881c-648120be36ca.png)

## その他
